### PR TITLE
Fixprod

### DIFF
--- a/Build/Build.proj
+++ b/Build/Build.proj
@@ -23,7 +23,7 @@
 		<MajorVersion>1</MajorVersion>
 		<MinorVersion>3</MinorVersion>
 		<VersionStartYear>2012</VersionStartYear>
-		<BuildNumber>1</BuildNumber>
+		<BuildNumber>3</BuildNumber>
 		<Revision Condition="'$(Revision)' == ''">$(BuildNumber)</Revision>
 		<Version>$(MajorVersion).$(MinorVersion).$(BuildNumber).$(Revision)</Version>
 	</PropertyGroup>

--- a/Common/CommonAssemblyInfo.cs
+++ b/Common/CommonAssemblyInfo.cs
@@ -8,5 +8,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: AssemblyVersion("1.3.1.0")]
-[assembly: AssemblyFileVersion("1.3.1.0")]
+[assembly: AssemblyVersion("1.3.3.0")]
+[assembly: AssemblyFileVersion("1.3.3.0")]

--- a/Efmap.nuspec
+++ b/Efmap.nuspec
@@ -2,7 +2,7 @@
 <package xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <id>Efmap</id>
-    <version>1.3.1.0</version>
+    <version>1.3.3.0</version>
     <authors>Rui Carvalho</authors>
     <owners>Rui Carvalho</owners>
     <licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>


### PR DESCRIPTION
Mappings were not working anymore with new way of doing autoload,
I didn't investigate if that comes from EF changes, but for previous apps using it I added the old fashion of doing autoload as `AutoLoadForThisContextWithDbSet`
